### PR TITLE
Account for Text Descenders

### DIFF
--- a/cli/image.py
+++ b/cli/image.py
@@ -70,6 +70,14 @@ def write_font_center(
         (0, 0), message, font=font, features=features
     )
 
+    # Figure out how far below the baseline the text goes
+    # "ls" is "left baseline" as our (0,0) anchor
+    _, _, _, descender_height = draw.textbbox(
+        (0, 0), message, anchor="ls", font=font, features=features
+    )
+
+    draw_height -= descender_height
+
     # Draw the text in the center of the image, accounting for offset
     draw.text(
         (


### PR DESCRIPTION
Titles including letters like "ygq" etc have bits that go "below the line", or in font terms they are descenders that go below the baseline.

As a result, those titles ended up not lining up vertically with ones that didn't.

I don't know if this is the most right way to fix it, but it's definitely an improvement in my eyes!

Here's before:
![showing descender bug](https://github.com/user-attachments/assets/a5a30c83-d44b-453f-b424-379ee78a3acd)

And then after:
![after fix](https://github.com/user-attachments/assets/d0e765a1-ede8-49e8-99a7-a4f57dee739f)

It's not perfect, but it never was. The one on the left (Collections) was made before my patch.

