### PR TITLE
Fix typing import for Python 3.13 compatibility

### DIFF
--- a/install/fix_install.py
+++ b/install/fix_install.py
@@ -11,7 +11,7 @@ from urllib.request import urlopen
 
 # Other package imports
 from PIL import features
-from typing.io import IO
+from typing import IO
 
 # Local imports
 from .config import Dll


### PR DESCRIPTION
The currently available version produces a following traceback with Python 3.13.

```
Traceback (most recent call last):
  File "/home/andy/.local/bin/jellyfin-cover", line 5, in <module>
    from cli.cli import main
  File "/home/andy/.local/share/pipx/venvs/jellyfin-tools/lib/python3.13/site-packages/cli/cli.py", line 7, in <module>
    from install import fix_install
  File "/home/andy/.local/share/pipx/venvs/jellyfin-tools/lib/python3.13/site-packages/install/fix_install.py", line 14, in <module>
    from typing.io import IO
ModuleNotFoundError: No module named 'typing.io'; 'typing' is not a package
```

Supposedly, `typing.io` was deprecated in earlier Python versions and appears to have been removed in 3.13. The recommended way is to import types from the base `typing` package: https://docs.python.org/3/library/typing.html#abcs-for-working-with-io